### PR TITLE
Allow keys registered with PRSRVKEY(KEYMAP0) to be used in KEYMAP1/2.

### DIFF
--- a/imcrvtip/KeyHandler.cpp
+++ b/imcrvtip/KeyHandler.cpp
@@ -378,7 +378,6 @@ void CTextService::_KeyboardOpenCloseChanged(BOOL showinputmode)
 			_LoadPreservedKey();
 
 			_InitPreservedKey(1);	//OFF
-			_InitPreservedKey(0);	//ON 未使用だがキーは拾う 重複するキーは上書きされない
 		}
 
 		_LoadCKeyMap();
@@ -425,7 +424,6 @@ void CTextService::_KeyboardOpenCloseChanged(BOOL showinputmode)
 			_LoadPreservedKey();
 
 			_InitPreservedKey(0);	//ON
-			_InitPreservedKey(1);	//OFF 未使用だがキーは拾う 重複するキーは上書きされない
 		}
 	}
 


### PR DESCRIPTION
Regarding the issue I raised in Issue #26.
since it was a bit complex to handle, you suggested an alternative, and I had been using that method for a while.

Recently, I found some spare time, so I decided to make the fix on my end.  
I’ve been using it for about a week in my daily work, and I haven’t encountered any issues so far.

