### PR TITLE
Fix lua.exe and lua55.dll not being installed

### DIFF
--- a/installer/installer-arm64.wxs
+++ b/installer/installer-arm64.wxs
@@ -48,11 +48,11 @@
       </Component>
       <Component Id="LUAEXE_ARM64" Guid="1A3572E7-942D-4F80-95B9-187681EA786A">
         <File Id="F_LUAEXE_ARM64" Name="lua.exe"
-          Source="..\build\ARM64\Release\lua.exe" CompanionFile="F_IMCRVMGR_ARM64" />
+          Source="..\build\ARM64\Release\lua.exe" KeyPath="yes" />
       </Component>
       <Component Id="LUADLL_ARM64" Guid="C20F192C-1DB0-47F5-AE91-0E07727DAB86">
         <File Id="F_LUADLL_ARM64" Name="lua55.dll"
-          Source="..\build\ARM64\Release\lua55.dll" CompanionFile="F_IMCRVMGR_ARM64" />
+          Source="..\build\ARM64\Release\lua55.dll" KeyPath="yes" />
       </Component>
       <Component Id="ZLIBDLL_ARM64" Guid="8B5418C2-ABB5-4907-A749-859856078508">
         <File Id="F_ZLIBDLL_ARM64" Name="zlib1.dll"

--- a/installer/installer-x64.wxs
+++ b/installer/installer-x64.wxs
@@ -47,11 +47,11 @@
       </Component>
       <Component Id="LUAEXE_X64" Guid="603A9A91-D244-4AA7-A8AD-56B2563C0C25">
         <File Id="F_LUAEXE_X64" Name="lua.exe"
-          Source="..\build\x64\Release\lua.exe" CompanionFile="F_IMCRVMGR_X64" />
+          Source="..\build\x64\Release\lua.exe" KeyPath="yes" />
       </Component>
       <Component Id="LUADLL_X64" Guid="39B37C2E-8821-47E8-98FE-00503A54894C">
         <File Id="F_LUADLL_X64" Name="lua55.dll"
-          Source="..\build\x64\Release\lua55.dll" CompanionFile="F_IMCRVMGR_X64" />
+          Source="..\build\x64\Release\lua55.dll" KeyPath="yes" />
       </Component>
       <Component Id="ZLIBDLL_X64" Guid="796681FD-4DAE-4658-A7C1-B87E6F2CCE6C">
         <File Id="F_ZLIBDLL_X64" Name="zlib1.dll"

--- a/installer/installer-x86.wxs
+++ b/installer/installer-x86.wxs
@@ -60,11 +60,11 @@
       </Component>
       <Component Id="LUAEXE_X86" Guid="288FF289-0EAA-405B-87ED-4F367D40546F">
         <File Id="F_LUAEXE_X86" Name="lua.exe"
-          Source="..\build\Win32\Release\lua.exe" CompanionFile="F_IMCRVMGR_X86" />
+          Source="..\build\Win32\Release\lua.exe" KeyPath="yes" />
       </Component>
       <Component Id="LUADLL_X86" Guid="84898511-4C96-4114-A7EE-8F32E260D28A">
         <File Id="F_LUADLL_X86" Name="lua55.dll"
-          Source="..\build\Win32\Release\lua55.dll" CompanionFile="F_IMCRVMGR_X86" />
+          Source="..\build\Win32\Release\lua55.dll" KeyPath="yes" />
       </Component>
       <Component Id="ZLIBDLL_X86" Guid="190D4F82-EFE6-4907-8DD6-B53E771D781E">
         <File Id="F_ZLIBDLL_X86" Name="zlib1.dll"


### PR DESCRIPTION
# Problem
After a fresh install, the application fails to start because `lua55.dll` 
(and `lua.exe`) are not present in the installation directory.
## Root Cause
`lua.exe` and `lua55.dll` components used the `CompanionFile` attribute 
referencing `imcrvmgr.exe`. The MSI `CompanionFile` mechanism skips 
installation of a file when its companion is considered up-to-date. 
However, `lua55.dll` is a versioned DLL (`FILEVERSION 5,5,0,0`), so 
this mechanism does not apply correctly and the files may not be installed.
## Fix
Replace `CompanionFile` with `KeyPath="yes"` in `LUAEXE` and `LUADLL` 
components across all three installer files (x64, x86, ARM64).
---
*Note: This PR was created with the assistance of Claude (AI by Anthropic).*
