### PR TITLE
Fix spurious space left after cancelling SKK input mode with BS or Left

### DIFF
--- a/imcrvtip/KeyHandlerComposition.cpp
+++ b/imcrvtip/KeyHandlerComposition.cpp
@@ -143,10 +143,7 @@ HRESULT CTextService::_Update(TfEditCookie ec, ITfContext *pContext, BOOL fixed,
 			{
 				if (!showmodemark)
 				{
-					if (kana.empty() && romandisp.empty())
-					{
-						comptext.append(markSP);
-					}
+					// markSP不要: kana/romanが空のときはコンポジションを開始しない
 				}
 				else
 				{
@@ -346,6 +343,10 @@ HRESULT CTextService::_SetText(TfEditCookie ec, ITfContext *pContext, const std:
 
 	if (!_IsComposing())
 	{
+		if (text.empty())
+		{
+			return S_OK;	// 空テキストで新規コンポジション開始不要
+		}
 		if (!_StartComposition(pContext))
 		{
 			return S_FALSE;

--- a/imcrvtip/KeyHandlerControl.cpp
+++ b/imcrvtip/KeyHandlerControl.cpp
@@ -745,7 +745,7 @@ HRESULT CTextService::_HandleControl(TfEditCookie ec, ITfContext *pContext, BYTE
 			}
 		}
 
-		if (!inputkey && roman.empty() && kana.empty())
+		if (roman.empty() && kana.empty())
 		{
 			_HandleCharReturn(ec, pContext);
 		}
@@ -829,6 +829,11 @@ HRESULT CTextService::_HandleControl(TfEditCookie ec, ITfContext *pContext, BYTE
 
 			if (inputkey)
 			{
+				if (roman.empty() && kana.empty())
+				{
+					_HandleCharReturn(ec, pContext);
+					return S_OK;
+				}
 				_HandleCharShift(ec, pContext);
 			}
 			else


### PR DESCRIPTION
## Problem

When entering conversion mode with SHIFT+consonant (e.g. SHIFT+S) and 
immediately pressing BS or Left Arrow to cancel, a half-width space 
remains in the composition. A second BS press is required to clear it.

## Root Cause

When `showmodemark=FALSE`, `_Update()` inserts `markSP` (U+0020) as a 
placeholder into the composition when `inputkey=TRUE` but kana and roman 
are both empty. Additionally, the SKK_BACK and SKK_LEFT handlers were not 
calling `_HandleCharReturn()` in all cases where cancellation should occur.

## Fix

- Remove `markSP` insertion in `_Update()` when `showmodemark=FALSE` and 
  kana/roman are empty — the composition is simply not started until actual 
  content exists
- Guard `_SetText()` to avoid starting a new empty composition
- In `SKK_BACK`: call `_HandleCharReturn()` when roman/kana become empty 
  after `pop_back()` (previously guarded by `!inputkey`, which was incorrect)
- In `SKK_LEFT`: call `_HandleCharReturn()` when `_ConvRoman()` clears 
  roman and kana is also empty

---
*Note: This PR was created with the assistance of Claude (AI by Anthropic).*