### PR TITLE
変換モードのキャンセル時にBS/左矢印を2回押す必要がある問題を修正

### DIFF
--- a/imcrvtip/KeyHandlerComposition.cpp
+++ b/imcrvtip/KeyHandlerComposition.cpp
@@ -143,10 +143,7 @@ HRESULT CTextService::_Update(TfEditCookie ec, ITfContext *pContext, BOOL fixed,
 			{
 				if (!showmodemark)
 				{
-					if (kana.empty() && romandisp.empty())
-					{
-						comptext.append(markSP);
-					}
+					// markSP不要: kana/romanが空のときはコンポジションを開始しない
 				}
 				else
 				{
@@ -346,6 +343,10 @@ HRESULT CTextService::_SetText(TfEditCookie ec, ITfContext *pContext, const std:
 
 	if (!_IsComposing())
 	{
+		if (text.empty())
+		{
+			return S_OK;	// 空テキストで新規コンポジション開始不要
+		}
 		if (!_StartComposition(pContext))
 		{
 			return S_FALSE;

--- a/imcrvtip/KeyHandlerComposition.cpp
+++ b/imcrvtip/KeyHandlerComposition.cpp
@@ -143,7 +143,10 @@ HRESULT CTextService::_Update(TfEditCookie ec, ITfContext *pContext, BOOL fixed,
 			{
 				if (!showmodemark)
 				{
-					// markSP不要: kana/romanが空のときはコンポジションを開始しない
+					if (kana.empty() && romandisp.empty())
+					{
+						comptext.append(markSP);
+					}
 				}
 				else
 				{
@@ -343,10 +346,6 @@ HRESULT CTextService::_SetText(TfEditCookie ec, ITfContext *pContext, const std:
 
 	if (!_IsComposing())
 	{
-		if (text.empty())
-		{
-			return S_OK;	// 空テキストで新規コンポジション開始不要
-		}
 		if (!_StartComposition(pContext))
 		{
 			return S_FALSE;

--- a/imcrvtip/KeyHandlerControl.cpp
+++ b/imcrvtip/KeyHandlerControl.cpp
@@ -745,7 +745,7 @@ HRESULT CTextService::_HandleControl(TfEditCookie ec, ITfContext *pContext, BYTE
 			}
 		}
 
-		if (!inputkey && roman.empty() && kana.empty())
+		if (roman.empty() && kana.empty())
 		{
 			_HandleCharReturn(ec, pContext);
 		}
@@ -829,6 +829,11 @@ HRESULT CTextService::_HandleControl(TfEditCookie ec, ITfContext *pContext, BYTE
 
 			if (inputkey)
 			{
+				if (roman.empty() && kana.empty())
+				{
+					_HandleCharReturn(ec, pContext);
+					return S_OK;
+				}
 				_HandleCharShift(ec, pContext);
 			}
 			else


### PR DESCRIPTION
## 問題
SHIFT+子音（例：SHIFT+S）でSKK変換モードに入った後、
BSまたは左矢印を押してキャンセルしようとすると1回では完了せず、
スペースが残ってしまうため2回押す必要がある。
## 修正内容
`KeyHandlerControl.cpp` のみ変更（`KeyHandlerComposition.cpp` は変更なし）：
- **SKK_BACK**：ガード条件から `!inputkey` を削除。ローマ字バッファが
  空になった時点で `_Update()` ではなく `_HandleCharReturn()` が呼ばれるようにした。
- **SKK_LEFT**：`_ConvRoman()` 後にローマ字・かなバッファが両方空の場合、
  `_HandleCharReturn()` を呼ぶ早期リターンを追加。
## 備考
#47 の修正版です。`KeyHandlerComposition.cpp` への変更は全て除いています。